### PR TITLE
Bump sphinx and rtd theme

### DIFF
--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -4,5 +4,5 @@ sphinx==7.2.6
 sphinx_rtd_theme==2.0.0
 sphinx_book_theme==1.1.2
 sphinx-automodapi==0.17.0
-sphinx-issues==3.0.1
+sphinx-issues==4.0.0
 nbsphinx==0.9.3


### PR DESCRIPTION
 - [ ] Need to bump ``sphinx-book-theme`` [failing CI doc test](https://github.com/ssec-jhu/bluephos/actions/runs/7101901279/job/19331063855?pr=10#step:4:155).
 ```python
The conflict is caused by:
    The user requested sphinx==7.2.6
    sphinx-rtd-theme 2.0.0 depends on sphinx<8 and >=5
    sphinx-book-theme 1.0.1 depends on sphinx<7 and >=4
```

Looks like there isn't a newer version of ``sphinx-book-theme`` > 1.0.1