### PR TITLE
Add --no_xtb Option to Disable xTB Optimization in Pipeline

### DIFF
--- a/bluephos/bluephos_pipeline.py
+++ b/bluephos/bluephos_pipeline.py
@@ -161,7 +161,6 @@ if __name__ == "__main__":
     ap.add_argument("--input_dir", required=False, help="Directory containing input parquet files")
     ap.add_argument("--t_nn", type=float, required=False, default=1.5, help="Threshold for 'z' score (default: 1.5)")
     ap.add_argument("--t_ste", type=float, required=False, default=1.9, help="Threshold for 'ste' (default: 1.9)")
-    # ap.add_argument("--xtb", required=False, default="True", help="Option to disable xTB by --xtb False (default:True)")
     ap.add_argument("--no_xtb", action="store_false", dest="xtb", help="Disable xTB optimization (default: enabled)")
 
     ap.add_argument(

--- a/bluephos/bluephos_pipeline.py
+++ b/bluephos/bluephos_pipeline.py
@@ -98,6 +98,7 @@ def get_pipeline(
     model_weights,  # Path to the model weights file
     input_dir=None,  # Directory containing input parquet files(rerun). Defaults to None.
     dft_package="orca",  # DFT package to use. Defaults to "orca".
+    xtb=True,  # Enable xTb optimize geometries task. Defaults to True.
     t_nn=1.5,  # Threshold for 'z' score. Defaults to None
     t_ste=1.9,  # Threshold for 'ste'. Defaults to None
 ):
@@ -139,6 +140,7 @@ def get_pipeline(
         "train_stats": train_stats,
         "model_weights": model_weights,
         "dft_package": dft_package,
+        "xtb": xtb,
         "t_nn": t_nn,
         "t_ste": t_ste,
     }
@@ -159,6 +161,8 @@ if __name__ == "__main__":
     ap.add_argument("--input_dir", required=False, help="Directory containing input parquet files")
     ap.add_argument("--t_nn", type=float, required=False, default=1.5, help="Threshold for 'z' score (default: 1.5)")
     ap.add_argument("--t_ste", type=float, required=False, default=1.9, help="Threshold for 'ste' (default: 1.9)")
+    # ap.add_argument("--xtb", required=False, default="True", help="Option to disable xTB by --xtb False (default:True)")
+    ap.add_argument("--no_xtb", action="store_false", dest="xtb", help="Disable xTB optimization (default: enabled)")
 
     ap.add_argument(
         "--dft_package",
@@ -180,6 +184,7 @@ if __name__ == "__main__":
             args.weights,
             args.input_dir,
             args.dft_package,
+            args.xtb,
             args.t_nn,
             args.t_ste,
         ),

--- a/bluephos/tasks/dft.py
+++ b/bluephos/tasks/dft.py
@@ -97,5 +97,5 @@ DFTTask = PipelineTask(
         "dft_package": "dft_package",  #  Either "ase" or "orca"
     },
     batch_size=1,
-    num_cpus=10,
+    num_cpus=32,
 )

--- a/bluephos/tasks/dft.py
+++ b/bluephos/tasks/dft.py
@@ -97,5 +97,5 @@ DFTTask = PipelineTask(
         "dft_package": "dft_package",  #  Either "ase" or "orca"
     },
     batch_size=1,
-    num_cpus=32,
+    num_cpus=10,
 )

--- a/tests/test_optimizegeometries_task.py
+++ b/tests/test_optimizegeometries_task.py
@@ -34,8 +34,11 @@ def test_optimize(mock_optimize_geometry, mock_octahedral_embed, setup_dataframe
     # Define a mock t_nn argument
     mock_t_nn = 1.5  # Replace with a suitable value for t_nn
 
+    # Define a mock xtb argument
+    mock_xtb = True
+
     # Run optimize
-    output_dataframe = optimize_geometries(setup_dataframe, mock_t_nn)
+    output_dataframe = optimize_geometries(setup_dataframe, mock_t_nn, mock_xtb)
 
     # Check if XYZ data was added or set to failed
     assert output_dataframe.loc[0, "xyz"] is not None


### PR DESCRIPTION
**Description:** This PR introduces the --no_xtb flag to allow users to disable xTB optimization and rely solely on the initial structure generated by octahedral_embed in the pipeline.
Changes:
**1. New --no_xtb Flag:**
xTB optimization is enabled by default. The --no_xtb option disables it.
Users can now choose to skip xTB optimization without modifying the pipeline code.
**2. Logging:**
Updated the log message when xTB is expected but not installed. Changed logging level to info to reflect this as an optional feature.
**3. CLI Update:**
Added --no_xtb to the argument parser using store_false to control xTB functionality.