### PR TITLE
remove anaconda in Channel

### DIFF
--- a/blue_env.yml
+++ b/blue_env.yml
@@ -1,6 +1,5 @@
 name: blue_env
 channels:
-  - anaconda
   - pytorch
   - conda-forge
   - defaults


### PR DESCRIPTION
To solve the CI error: "UnavailableInvalidChannel: HTTP 403 FORBIDDEN for channel anaconda"