### PR TITLE
docs: remove nbsphinx (not used)

### DIFF
--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -5,4 +5,3 @@ sphinx_rtd_theme==3.0.2
 sphinx_book_theme==1.1.4
 sphinx-automodapi==0.18.0
 sphinx-issues==5.0.0
-nbsphinx==0.9.7


### PR DESCRIPTION
This PR removes `nbsphinx` from the documentation requirements as it is no longer used:

- No notebooks are included in the Sphinx docs
- `conf.py` does not list `nbsphinx`
- Confirmed successful `sphinx-build` without it

This also allows safe upgrades to `sphinx>=8.2` without triggering dependency conflicts.
